### PR TITLE
Qol register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,14 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.4",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -284,9 +289,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
+checksum = "4c9d0958efb8301e1626692ea879cbff622ef45cf731807ec8d488b34be98cb8"
 dependencies = [
  "borsh-derive",
  "hashbrown",
@@ -294,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
+checksum = "325164710ad57bae6d32455ce3bd384f95768464a927ce145626dc3390a7f9fe"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
@@ -307,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+checksum = "f74159f43b231f4af8c4ce4967fef76e4e59725acf51706ddb9268c94348d15c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -318,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
+checksum = "99b2a77771907a820a860d200d193a0787c79a7890c8e253c462fa0f51ad58b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,15 +526,26 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.9.1"
+name = "getrandom"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
@@ -753,6 +769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +853,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyth-client"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a99198087943003b585590a42c3e323523b94a2c9e1df3e2636ebce39535a26"
+dependencies = [
+ "borsh",
+ "borsh-derive",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,7 +882,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -868,7 +905,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1071,7 +1108,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom",
+ "getrandom 0.1.16",
  "itertools",
  "js-sys",
  "lazy_static",
@@ -1139,6 +1176,8 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "borsh",
+ "pyth-client",
  "spl-token",
 ]
 
@@ -1226,6 +1265,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint .",
     "prepare": "husky install",
     "typecheck": "tsc",
-    "test": "anchor test --skip-build tests/*.ts"
+    "test": "anchor test"
   },
   "dependencies": {},
   "devDependencies": {

--- a/programs/splitcoin-prism/Cargo.toml
+++ b/programs/splitcoin-prism/Cargo.toml
@@ -16,6 +16,8 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
+pyth-client = { version = "0.3.0", features = ["no-entrypoint"] }
 anchor-lang = "0.19.0"
 anchor-spl = "0.19.0"
+borsh = "0.9.2"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }

--- a/programs/splitcoin-prism/Cargo.toml
+++ b/programs/splitcoin-prism/Cargo.toml
@@ -19,5 +19,5 @@ default = []
 pyth-client = { version = "0.3.0", features = ["no-entrypoint"] }
 anchor-lang = "0.19.0"
 anchor-spl = "0.19.0"
-borsh = "0.9.2"
+borsh = { version = "0.9.2", features = ["const-generics"] }
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }

--- a/programs/splitcoin-prism/src/asset_data.rs
+++ b/programs/splitcoin-prism/src/asset_data.rs
@@ -1,13 +1,16 @@
 use pyth_client::PriceConf;
-use borsh::{BorshDeserialize, BorshSerialize};
 
-#[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize)]
-pub struct AssetData<T: ReadablePrice = ConstantValueFeed> {
-    pub data_feed: T,
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+
+#[derive(Debug, Copy, Clone, AnchorDeserialize, AnchorSerialize)]
+pub struct AssetData<Feed = ConstantValueFeed> 
+    where Feed: ReadablePrice + anchor_lang::AnchorDeserialize + anchor_lang::AnchorSerialize {
+    pub data_feed: Feed,
     pub weight: i64,
 }
 
-impl<ConstantValueFeed: ReadablePrice + Default> Default for AssetData<ConstantValueFeed> {
+impl<ConstantValueFeed> Default for AssetData<ConstantValueFeed> 
+    where ConstantValueFeed: ReadablePrice + anchor_lang::AnchorDeserialize + anchor_lang::AnchorSerialize + Default {
         fn default() -> Self {
             AssetData {
                 data_feed: ConstantValueFeed::default(),
@@ -20,7 +23,7 @@ pub trait ReadablePrice {
     fn get_price(&self) -> PriceConf; 
 }
 
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, AnchorDeserialize, AnchorSerialize)]
 pub struct ConstantValueFeed {
     pub constant: i64,
     pub expo: i32,

--- a/programs/splitcoin-prism/src/asset_data.rs
+++ b/programs/splitcoin-prism/src/asset_data.rs
@@ -2,41 +2,38 @@ use pyth_client::PriceConf;
 
 use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 
-#[derive(Debug, Copy, Clone, AnchorDeserialize, AnchorSerialize)]
-pub struct AssetData<Feed = ConstantValueFeed> 
-    where Feed: ReadablePrice + anchor_lang::AnchorDeserialize + anchor_lang::AnchorSerialize {
+#[derive(Debug, Clone, Copy, Default, AnchorDeserialize, AnchorSerialize)]
+pub struct AssetData {
     pub data_feed: Feed,
     pub weight: i64,
 }
 
-impl<ConstantValueFeed> Default for AssetData<ConstantValueFeed> 
-    where ConstantValueFeed: ReadablePrice + anchor_lang::AnchorDeserialize + anchor_lang::AnchorSerialize + Default {
-        #[inline(never)]
-        fn default() -> Self {
-            AssetData {
-                data_feed: ConstantValueFeed::default(),
-                weight: 0,
-            }
-        }
+#[derive(Debug, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
+pub enum Feed {
+    Constant { price: i64, expo: i32 },
+}
+
+impl Default for Feed {
+    fn default() -> Self {
+        Feed::Constant { price: 0, expo: 0 }
+    }
 }
 
 pub trait ReadablePrice {
-    fn get_price(&self) -> PriceConf; 
+    fn get_price(&self) -> PriceConf;
 }
 
-#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, AnchorDeserialize, AnchorSerialize)]
-pub struct ConstantValueFeed {
-    pub constant: i64,
-    pub expo: i32,
-}
-
-impl ReadablePrice for ConstantValueFeed {
+impl ReadablePrice for Feed {
     #[inline(never)]
     fn get_price(&self) -> PriceConf {
-        PriceConf {
-            price: self.constant,
-            conf: 0,
-            expo: self.expo,
+        use Feed::*;
+
+        match *self {
+            Constant { price, expo } => PriceConf {
+                price,
+                conf: 0,
+                expo,
+            },
         }
     }
 }

--- a/programs/splitcoin-prism/src/asset_data.rs
+++ b/programs/splitcoin-prism/src/asset_data.rs
@@ -11,6 +11,7 @@ pub struct AssetData<Feed = ConstantValueFeed>
 
 impl<ConstantValueFeed> Default for AssetData<ConstantValueFeed> 
     where ConstantValueFeed: ReadablePrice + anchor_lang::AnchorDeserialize + anchor_lang::AnchorSerialize + Default {
+        #[inline(never)]
         fn default() -> Self {
             AssetData {
                 data_feed: ConstantValueFeed::default(),
@@ -30,6 +31,7 @@ pub struct ConstantValueFeed {
 }
 
 impl ReadablePrice for ConstantValueFeed {
+    #[inline(never)]
     fn get_price(&self) -> PriceConf {
         PriceConf {
             price: self.constant,

--- a/programs/splitcoin-prism/src/asset_data.rs
+++ b/programs/splitcoin-prism/src/asset_data.rs
@@ -1,0 +1,37 @@
+use pyth_client::PriceConf;
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize)]
+pub struct AssetData<T: ReadablePrice = ConstantValueFeed> {
+    pub data_feed: T,
+    pub weight: i64,
+}
+
+impl<ConstantValueFeed: ReadablePrice + Default> Default for AssetData<ConstantValueFeed> {
+        fn default() -> Self {
+            AssetData {
+                data_feed: ConstantValueFeed::default(),
+                weight: 0,
+            }
+        }
+}
+
+pub trait ReadablePrice {
+    fn get_price(&self) -> PriceConf; 
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct ConstantValueFeed {
+    pub constant: i64,
+    pub expo: i32,
+}
+
+impl ReadablePrice for ConstantValueFeed {
+    fn get_price(&self) -> PriceConf {
+        PriceConf {
+            price: self.constant,
+            conf: 0,
+            expo: self.expo,
+        }
+    }
+}

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -1,4 +1,5 @@
 use crate::state::*;
+
 use anchor_lang::prelude::*;
 use anchor_spl::{
     associated_token::AssociatedToken,
@@ -8,6 +9,7 @@ use anchor_spl::{
 #[derive(Accounts)]
 #[instruction(bump: u8)]
 pub struct Initialize<'info> {
+    /// The central mint authority for all registered tokens
     #[account(
         init,
         seeds = [
@@ -16,7 +18,6 @@ pub struct Initialize<'info> {
         bump = bump,
         payer = owner,
     )]
-    /// The central mint authority for all registered tokens
     pub prism: Account<'info, Prism>,
     /// The owner of the Prism program
     pub owner: Signer<'info>,
@@ -70,9 +71,9 @@ pub struct Convert<'info> {
     /// The [Mint] of the burned tokens
     pub from_mint: Account<'info, Mint>,
 
+    /// The paying [TokenAccount]
     #[account(owner = payer.key())]
     #[account(associated_token::mint = from_mint, associated_token::authority = prism)]
-    /// The paying [TokenAccount]
     pub from: Account<'info, TokenAccount>,
 
     #[account(
@@ -88,11 +89,11 @@ pub struct Convert<'info> {
     /// The [Mint] of the minted tokens
     pub to_mint: Account<'info, Mint>,
 
+    /// The receiving [Account]
     #[account(associated_token::mint = to_mint, associated_token::authority = prism)]
-    /// The receiving [TokenAccount]
     pub to: Account<'info, TokenAccount>,
 
-    /// The payer of the tx
+    /// The payer ([Signer]) of the tx
     pub payer: Signer<'info>,
 
     /// The [Token] [Program].

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -1,7 +1,9 @@
 use crate::state::*;
 use anchor_lang::prelude::*;
-use anchor_spl::{token::{Mint, Token, TokenAccount}, associated_token::AssociatedToken};
-
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{Mint, Token, TokenAccount},
+};
 
 #[derive(Accounts)]
 #[instruction(bump: u8)]
@@ -35,7 +37,7 @@ pub struct RegisterToken<'info> {
         bump = bump,
         payer = admin_authority,
     )]
-    pub prism_token: Box<Account<'info, PrismToken>>,
+    pub prism_token: Account<'info, PrismToken>,
     /// Authority that has admin rights over the [PrismToken].
     pub admin_authority: Signer<'info>,
     /// [Mint] of the [PrismToken].
@@ -63,7 +65,7 @@ pub struct Convert<'info> {
         bump = from_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the incoming tokens to burn
-    pub from_token: Box<Account<'info, PrismToken>>,
+    pub from_token: Account<'info, PrismToken>,
 
     /// The [Mint] of the burned tokens
     pub from_mint: Account<'info, Mint>,
@@ -71,7 +73,7 @@ pub struct Convert<'info> {
     #[account(owner = payer.key())]
     #[account(associated_token::mint = from_mint, associated_token::authority = prism)]
     /// The paying [TokenAccount]
-    pub from: Box<Account<'info, TokenAccount>>,
+    pub from: Account<'info, TokenAccount>,
 
     #[account(
         seeds = [
@@ -81,7 +83,7 @@ pub struct Convert<'info> {
         bump = to_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the outgoing tokens to mint
-    pub to_token: Box<Account<'info, PrismToken>>,
+    pub to_token: Account<'info, PrismToken>,
 
     /// The [Mint] of the minted tokens
     pub to_mint: Account<'info, Mint>,

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -2,6 +2,7 @@ use crate::state::*;
 use anchor_lang::prelude::*;
 use anchor_spl::{token::{Mint, Token, TokenAccount}, associated_token::AssociatedToken};
 
+
 #[derive(Accounts)]
 #[instruction(bump: u8)]
 pub struct Initialize<'info> {

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -38,7 +38,7 @@ pub struct RegisterToken<'info> {
         bump = bump,
         payer = admin_authority,
     )]
-    pub prism_token: Account<'info, PrismToken>,
+    pub prism_token: Box<Account<'info, PrismToken>>,
     /// Authority that has admin rights over the [PrismToken].
     pub admin_authority: Signer<'info>,
     /// [Mint] of the [PrismToken].
@@ -66,7 +66,7 @@ pub struct Convert<'info> {
         bump = from_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the incoming tokens to burn
-    pub from_token: Account<'info, PrismToken>,
+    pub from_token: Box<Account<'info, PrismToken>>,
 
     /// The [Mint] of the burned tokens
     pub from_mint: Account<'info, Mint>,
@@ -84,7 +84,7 @@ pub struct Convert<'info> {
         bump = to_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the outgoing tokens to mint
-    pub to_token: Account<'info, PrismToken>,
+    pub to_token: Box<Account<'info, PrismToken>>,
 
     /// The [Mint] of the minted tokens
     pub to_mint: Account<'info, Mint>,

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -35,7 +35,7 @@ pub struct RegisterToken<'info> {
         bump = bump,
         payer = admin_authority,
     )]
-    pub prism_token: Account<'info, PrismToken>,
+    pub prism_token: Box<Account<'info, PrismToken>>,
     /// Authority that has admin rights over the [PrismToken].
     pub admin_authority: Signer<'info>,
     /// [Mint] of the [PrismToken].
@@ -63,7 +63,7 @@ pub struct Convert<'info> {
         bump = from_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the incoming tokens to burn
-    pub from_token: Account<'info, PrismToken>,
+    pub from_token: Box<Account<'info, PrismToken>>,
 
     /// The [Mint] of the burned tokens
     pub from_mint: Account<'info, Mint>,
@@ -71,7 +71,7 @@ pub struct Convert<'info> {
     #[account(owner = payer.key())]
     #[account(associated_token::mint = from_mint, associated_token::authority = prism)]
     /// The paying [TokenAccount]
-    pub from: Account<'info, TokenAccount>,
+    pub from: Box<Account<'info, TokenAccount>>,
 
     #[account(
         seeds = [
@@ -81,7 +81,7 @@ pub struct Convert<'info> {
         bump = to_token.bump
     )]
     /// The [PrismToken] [Account] used for calculating the outgoing tokens to mint
-    pub to_token: Account<'info, PrismToken>,
+    pub to_token: Box<Account<'info, PrismToken>>,
 
     /// The [Mint] of the minted tokens
     pub to_mint: Account<'info, Mint>,

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -1,6 +1,6 @@
 use crate::state::*;
 use anchor_lang::prelude::*;
-use anchor_spl::token::Mint;
+use anchor_spl::{token::{Mint, Token, TokenAccount}, associated_token::AssociatedToken};
 
 #[derive(Accounts)]
 #[instruction(bump: u8)]
@@ -41,4 +41,60 @@ pub struct NewAsset<'info> {
     pub asset_mint: Account<'info, Mint>,
     /// The [System] program.
     pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Convert<'info> {
+    /// The [Prism] authority account
+    #[account(
+        seeds = [
+            b"Prism".as_ref(),
+        ],
+        bump = prism.bump,
+    )]
+    pub prism: Account<'info, Prism>,
+
+    #[account(
+        seeds = [
+            b"PrismAsset".as_ref(),
+            from_mint.key().to_bytes().as_ref()
+        ],
+        bump = from_asset.bump
+    )]
+    /// The [PrismAsset] [Account] used for calculating the incoming tokens to burn
+    pub from_asset: Account<'info, PrismAsset>,
+
+    /// The [Mint] of the burned tokens
+    pub from_mint: Account<'info, Mint>,
+
+    #[account(owner = payer.key())]
+    #[account(associated_token::mint = from_mint, associated_token::authority = prism)]
+    /// The paying [TokenAccount]
+    pub from: Account<'info, TokenAccount>,
+
+    #[account(
+        seeds = [
+            b"PrismAsset".as_ref(),
+            to_mint.key().to_bytes().as_ref()
+        ],
+        bump = to_asset.bump
+    )]
+    /// The [PrismAsset] [Account] used for calculating the outgoing tokens to mint
+    pub to_asset: Account<'info, PrismAsset>,
+
+    /// The [Mint] of the minted tokens
+    pub to_mint: Account<'info, Mint>,
+
+    #[account(associated_token::mint = to_mint, associated_token::authority = prism)]
+    /// The receiving [TokenAccount]
+    pub to: Account<'info, TokenAccount>,
+
+    /// The payer of the tx
+    pub payer: Signer<'info>,
+
+    /// The [Token] [Program].
+    pub token_program: Program<'info, Token>,
+
+    /// The [AssociatedToken] [Program]
+    pub associated_program: Program<'info, AssociatedToken>,
 }

--- a/programs/splitcoin-prism/src/context.rs
+++ b/programs/splitcoin-prism/src/context.rs
@@ -14,7 +14,7 @@ pub struct Initialize<'info> {
         bump = bump,
         payer = owner,
     )]
-    /// The central mint authority for all registered assets
+    /// The central mint authority for all registered tokens
     pub prism: Account<'info, Prism>,
     /// The owner of the Prism program
     pub owner: Signer<'info>,
@@ -24,22 +24,22 @@ pub struct Initialize<'info> {
 
 #[derive(Accounts)]
 #[instruction(bump: u8)]
-pub struct NewAsset<'info> {
-    /// Information about the [PrismAsset].
+pub struct RegisterToken<'info> {
+    /// Information about the [PrismToken].
     #[account(
         init,
         seeds = [
-            b"PrismAsset".as_ref(),
-            asset_mint.key().to_bytes().as_ref()
+            b"PrismToken".as_ref(),
+            token_mint.key().to_bytes().as_ref()
         ],
         bump = bump,
         payer = admin_authority,
     )]
-    pub prism_asset: Account<'info, PrismAsset>,
-    /// Authority that has admin rights over the [PrismAsset].
+    pub prism_token: Account<'info, PrismToken>,
+    /// Authority that has admin rights over the [PrismToken].
     pub admin_authority: Signer<'info>,
-    /// [Mint] of the [PrismAsset].
-    pub asset_mint: Account<'info, Mint>,
+    /// [Mint] of the [PrismToken].
+    pub token_mint: Account<'info, Mint>,
     /// The [System] program.
     pub system_program: Program<'info, System>,
 }
@@ -57,13 +57,13 @@ pub struct Convert<'info> {
 
     #[account(
         seeds = [
-            b"PrismAsset".as_ref(),
+            b"PrismToken".as_ref(),
             from_mint.key().to_bytes().as_ref()
         ],
-        bump = from_asset.bump
+        bump = from_token.bump
     )]
-    /// The [PrismAsset] [Account] used for calculating the incoming tokens to burn
-    pub from_asset: Account<'info, PrismAsset>,
+    /// The [PrismToken] [Account] used for calculating the incoming tokens to burn
+    pub from_token: Account<'info, PrismToken>,
 
     /// The [Mint] of the burned tokens
     pub from_mint: Account<'info, Mint>,
@@ -75,13 +75,13 @@ pub struct Convert<'info> {
 
     #[account(
         seeds = [
-            b"PrismAsset".as_ref(),
+            b"PrismToken".as_ref(),
             to_mint.key().to_bytes().as_ref()
         ],
-        bump = to_asset.bump
+        bump = to_token.bump
     )]
-    /// The [PrismAsset] [Account] used for calculating the outgoing tokens to mint
-    pub to_asset: Account<'info, PrismAsset>,
+    /// The [PrismToken] [Account] used for calculating the outgoing tokens to mint
+    pub to_token: Account<'info, PrismToken>,
 
     /// The [Mint] of the minted tokens
     pub to_mint: Account<'info, Mint>,

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -1,5 +1,6 @@
 mod context;
 mod state;
+pub mod asset_data;
 
 use anchor_lang::prelude::*;
 use context::*;
@@ -32,6 +33,8 @@ pub mod splitcoin_prism {
     }
 
     pub fn convert(ctx: Context<Convert>) -> ProgramResult {
+
         Ok(())
     }
+
 }

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -3,6 +3,7 @@ mod state;
 pub mod asset_data;
 
 use anchor_lang::prelude::*;
+use crate::asset_data::*;
 use context::*;
 
 declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
@@ -10,6 +11,8 @@ declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 #[program]
 pub mod splitcoin_prism {
     
+    use asset_data::AssetData;
+
     use super::*;
 
     /// Initializes the Prism program state
@@ -23,12 +26,14 @@ pub mod splitcoin_prism {
 
     /// Registers a new Prism Token
     #[inline(never)]
-    pub fn register_token(ctx: Context<RegisterToken>, bump: u8) -> ProgramResult {
+    pub fn register_token(ctx: Context<RegisterToken>, bump: u8, assets: [AssetData; 2]) -> ProgramResult {
         let prism = &mut ctx.accounts.prism_token;
 
         prism.authority = ctx.accounts.admin_authority.key();
         prism.bump = bump;
         prism.mint = ctx.accounts.token_mint.key();
+
+        prism.assets = assets;
 
         Ok(())
     }

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -8,6 +8,7 @@ declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 
 #[program]
 pub mod splitcoin_prism {
+
     use super::*;
 
     /// Initializes the Prism program state
@@ -27,6 +28,10 @@ pub mod splitcoin_prism {
         prism.bump = bump;
         prism.mint = ctx.accounts.asset_mint.key();
 
+        Ok(())
+    }
+
+    pub fn convert(ctx: Context<Convert>) -> ProgramResult {
         Ok(())
     }
 }

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -1,9 +1,12 @@
-pub mod asset_data;
-mod context;
-mod state;
 
-use crate::asset_data::*;
+pub mod context;
+pub mod state;
+pub mod asset_data;
+pub mod util;
+
 use anchor_lang::prelude::*;
+use asset_data::*;
+use util::token_value;
 use context::*;
 
 declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
@@ -11,6 +14,7 @@ declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 #[program]
 pub mod splitcoin_prism {
 
+    use anchor_spl::token::{burn, mint_to, Burn, MintTo};
     use asset_data::AssetData;
 
     use super::*;
@@ -39,12 +43,35 @@ pub mod splitcoin_prism {
 
         prism.assets = assets;
 
+        // Add token address to a registry account
+
         Ok(())
     }
 
+    /// Converts one prism token to another
     #[inline(never)]
-    pub fn convert(ctx: Context<Convert>) -> ProgramResult {
-        //let prism
+    pub fn convert(ctx: Context<Convert>, from_amount: u64) -> ProgramResult {
+    
+        let from_asset_value = token_value(&ctx.accounts.from_token.assets) as u64;
+        let to_asset_value = token_value(&ctx.accounts.to_token.assets) as u64;
+
+        // Amount of value being transferred
+        let effective_value = from_amount * from_asset_value;
+        // Amount of outgoing tokens to mint
+        let to_amount = effective_value / to_asset_value;
+
+        // Accounts used by burn cpi instruction
+        let burn_accounts = Burn { mint: ctx.accounts.from_mint.to_account_info(), to: ctx.accounts.from.to_account_info(), authority: ctx.accounts.prism.to_account_info()};
+
+        // Accounts used by mint cpi instruction
+        let mint_accounts = MintTo { mint: ctx.accounts.to_mint.to_account_info(), to: ctx.accounts.to.to_account_info(), authority: ctx.accounts.prism.to_account_info() };
+
+        let burn_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), burn_accounts);
+        burn(burn_ctx, from_amount)?;
+
+        let mint_to_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(),mint_accounts);
+        mint_to(mint_to_ctx, to_amount)?;
+
         Ok(())
     }
 }

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -9,7 +9,7 @@ declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 
 #[program]
 pub mod splitcoin_prism {
-
+    
     use super::*;
 
     /// Initializes the Prism program state
@@ -21,19 +21,21 @@ pub mod splitcoin_prism {
         Ok(())
     }
 
-    /// Provisions a new PrismAsset
-    pub fn new_asset(ctx: Context<NewAsset>, bump: u8) -> ProgramResult {
-        let prism = &mut ctx.accounts.prism_asset;
+    /// Registers a new PrismToken
+    #[inline(never)]
+    pub fn register_token(ctx: Context<RegisterToken>, bump: u8) -> ProgramResult {
+        let prism = &mut ctx.accounts.prism_token;
 
         prism.authority = ctx.accounts.admin_authority.key();
         prism.bump = bump;
-        prism.mint = ctx.accounts.asset_mint.key();
+        prism.mint = ctx.accounts.token_mint.key();
 
         Ok(())
     }
 
+    #[inline(never)]
     pub fn convert(ctx: Context<Convert>) -> ProgramResult {
-
+        //let prism
         Ok(())
     }
 

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -1,13 +1,12 @@
-
+pub mod asset_data;
 pub mod context;
 pub mod state;
-pub mod asset_data;
 pub mod util;
 
 use anchor_lang::prelude::*;
 use asset_data::*;
-use util::token_value;
 use context::*;
+use util::token_value;
 
 declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 
@@ -29,7 +28,6 @@ pub mod splitcoin_prism {
     }
 
     /// Registers a new Prism Token
-    #[inline(never)]
     pub fn register_token(
         ctx: Context<RegisterToken>,
         bump: u8,
@@ -41,9 +39,11 @@ pub mod splitcoin_prism {
         prism.bump = bump;
         prism.mint = ctx.accounts.token_mint.key();
 
-        prism.assets = assets;
+        for i in 0..assets.len() {
+            prism.assets[i] = assets[i];
+        }
 
-        // Add token address to a registry account
+        // TODO Add token address to a registry account
 
         Ok(())
     }
@@ -51,7 +51,6 @@ pub mod splitcoin_prism {
     /// Converts one prism token to another
     #[inline(never)]
     pub fn convert(ctx: Context<Convert>, from_amount: u64) -> ProgramResult {
-    
         let from_asset_value = token_value(&ctx.accounts.from_token.assets) as u64;
         let to_asset_value = token_value(&ctx.accounts.to_token.assets) as u64;
 
@@ -61,15 +60,24 @@ pub mod splitcoin_prism {
         let to_amount = effective_value / to_asset_value;
 
         // Accounts used by burn cpi instruction
-        let burn_accounts = Burn { mint: ctx.accounts.from_mint.to_account_info(), to: ctx.accounts.from.to_account_info(), authority: ctx.accounts.prism.to_account_info()};
+        let burn_accounts = Burn {
+            mint: ctx.accounts.from_mint.to_account_info(),
+            to: ctx.accounts.from.to_account_info(),
+            authority: ctx.accounts.prism.to_account_info(),
+        };
 
         // Accounts used by mint cpi instruction
-        let mint_accounts = MintTo { mint: ctx.accounts.to_mint.to_account_info(), to: ctx.accounts.to.to_account_info(), authority: ctx.accounts.prism.to_account_info() };
+        let mint_accounts = MintTo {
+            mint: ctx.accounts.to_mint.to_account_info(),
+            to: ctx.accounts.to.to_account_info(),
+            authority: ctx.accounts.prism.to_account_info(),
+        };
 
         let burn_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), burn_accounts);
         burn(burn_ctx, from_amount)?;
 
-        let mint_to_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(),mint_accounts);
+        let mint_to_ctx =
+            CpiContext::new(ctx.accounts.token_program.to_account_info(), mint_accounts);
         mint_to(mint_to_ctx, to_amount)?;
 
         Ok(())

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -1,16 +1,16 @@
+pub mod asset_data;
 mod context;
 mod state;
-pub mod asset_data;
 
-use anchor_lang::prelude::*;
 use crate::asset_data::*;
+use anchor_lang::prelude::*;
 use context::*;
 
 declare_id!("4WWKCwKfhz7cVkd4sANskBk3y2aG9XpZ3fGSQcW1yTBB");
 
 #[program]
 pub mod splitcoin_prism {
-    
+
     use asset_data::AssetData;
 
     use super::*;
@@ -26,7 +26,11 @@ pub mod splitcoin_prism {
 
     /// Registers a new Prism Token
     #[inline(never)]
-    pub fn register_token(ctx: Context<RegisterToken>, bump: u8, assets: [AssetData; 2]) -> ProgramResult {
+    pub fn register_token(
+        ctx: Context<RegisterToken>,
+        bump: u8,
+        assets: Vec<AssetData>,
+    ) -> ProgramResult {
         let prism = &mut ctx.accounts.prism_token;
 
         prism.authority = ctx.accounts.admin_authority.key();
@@ -43,5 +47,4 @@ pub mod splitcoin_prism {
         //let prism
         Ok(())
     }
-
 }

--- a/programs/splitcoin-prism/src/lib.rs
+++ b/programs/splitcoin-prism/src/lib.rs
@@ -21,7 +21,7 @@ pub mod splitcoin_prism {
         Ok(())
     }
 
-    /// Registers a new PrismToken
+    /// Registers a new Prism Token
     #[inline(never)]
     pub fn register_token(ctx: Context<RegisterToken>, bump: u8) -> ProgramResult {
         let prism = &mut ctx.accounts.prism_token;

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::asset_data::AssetData;
+use crate::asset_data::{AssetData, Feed};
 
 /// Contains the info of the prism token. Immutable.
 #[account]
@@ -12,18 +12,24 @@ pub struct PrismToken {
     pub bump: u8,
     /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
+    // TODO: replace 8 with shared max size
+    // TODO: find way to have optional serialization
     /// [AssetData] array
-    pub assets: Vec<AssetData>,
+    pub assets: [AssetData; 8],
 }
 
 impl Default for PrismToken {
     #[inline(never)]
     fn default() -> PrismToken {
+        // TODO replace 8 with shared max size
         PrismToken {
             authority: Default::default(),
             bump: Default::default(),
             mint: Default::default(),
-            assets: Vec::new(),
+            assets: [AssetData {
+                data_feed: Feed::Constant { price: 0, expo: 0 },
+                weight: 0,
+            }; 8],
         }
     }
 }

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -1,8 +1,10 @@
 use anchor_lang::prelude::*;
 
+use crate::asset_data::AssetData;
+
 /// Contains the info of the prism token. Immutable.
 #[account]
-#[derive(Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct PrismAsset {
     /// Authority that has admin rights over the [PrismAsset].
     pub authority: Pubkey,
@@ -10,7 +12,10 @@ pub struct PrismAsset {
     pub bump: u8,
     /// [Mint] of the [PrismAsset]
     pub mint: Pubkey,
+    /// [AssetData] array
+    pub assets: [AssetData; 32]
 }
+
 
 #[account]
 #[derive(Copy, Debug, Default, PartialEq, Eq)]

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -2,11 +2,6 @@ use anchor_lang::prelude::*;
 
 use crate::asset_data::AssetData;
 
-// TODO use constant generics here. Not doing it now because
-// having a problem with IDL generation right now look into
-#[constant]
-//const NUM_ASSETS: usize = 256;
-
 /// Contains the info of the prism token. Immutable.
 #[account]
 #[derive(Debug)]

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -16,12 +16,12 @@ pub struct PrismAsset {
     /// [Mint] of the [PrismAsset]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 16384]
+    pub assets: [AssetData; 16]
 }
 
 impl Default for PrismAsset {
     fn default() -> PrismAsset {
-        PrismAsset { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 16384] }
+        PrismAsset { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 16] }
     }
 }
 

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -2,9 +2,12 @@ use anchor_lang::prelude::*;
 
 use crate::asset_data::AssetData;
 
+// TODO use constant generics here. Not doing it now because
+// having a problem with IDL generation right now look into
+
 /// Contains the info of the prism token. Immutable.
 #[account]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PrismAsset {
     /// Authority that has admin rights over the [PrismAsset].
     pub authority: Pubkey,
@@ -13,9 +16,14 @@ pub struct PrismAsset {
     /// [Mint] of the [PrismAsset]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 32]
+    pub assets: [AssetData; 16384]
 }
 
+impl Default for PrismAsset {
+    fn default() -> PrismAsset {
+        PrismAsset { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 16384] }
+    }
+}
 
 #[account]
 #[derive(Copy, Debug, Default, PartialEq, Eq)]

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -5,7 +5,7 @@ use crate::asset_data::AssetData;
 // TODO use constant generics here. Not doing it now because
 // having a problem with IDL generation right now look into
 #[constant]
-const NUM_ASSETS: usize = 256;
+//const NUM_ASSETS: usize = 256;
 
 /// Contains the info of the prism token. Immutable.
 #[account]
@@ -18,13 +18,13 @@ pub struct PrismToken {
     /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: Box<[AssetData; NUM_ASSETS]>,
+    pub assets: [AssetData; 256],
 }
 
 impl Default for PrismToken {
     #[inline(never)]
     fn default() -> PrismToken {
-        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: Box::new([AssetData::default(); NUM_ASSETS]) }
+        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 256] }
     }
 }
 

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -18,13 +18,13 @@ pub struct PrismToken {
     /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 4],
+    pub assets: [AssetData; 2],
 }
 
 impl Default for PrismToken {
     #[inline(never)]
     fn default() -> PrismToken {
-        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 4] }
+        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 2] }
     }
 }
 

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -4,29 +4,32 @@ use crate::asset_data::AssetData;
 
 // TODO use constant generics here. Not doing it now because
 // having a problem with IDL generation right now look into
+#[constant]
+const NUM_ASSETS: usize = 256;
 
 /// Contains the info of the prism token. Immutable.
 #[account]
 #[derive(Debug)]
-pub struct PrismAsset {
-    /// Authority that has admin rights over the [PrismAsset].
+pub struct PrismToken {
+    /// Authority that has admin rights over the [PrismToken].
     pub authority: Pubkey,
     /// Bump seed. Stored for find_program_address on-chain performance
     pub bump: u8,
-    /// [Mint] of the [PrismAsset]
+    /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 16]
+    pub assets: Box<[AssetData; NUM_ASSETS]>,
 }
 
-impl Default for PrismAsset {
-    fn default() -> PrismAsset {
-        PrismAsset { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 16] }
+impl Default for PrismToken {
+    #[inline(never)]
+    fn default() -> PrismToken {
+        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: Box::new([AssetData::default(); NUM_ASSETS]) }
     }
 }
 
 #[account]
-#[derive(Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Debug, Default)]
 pub struct Prism {
     /// Owner of Prism program
     pub owner: Pubkey,

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -18,13 +18,18 @@ pub struct PrismToken {
     /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 2],
+    pub assets: Vec<AssetData>,
 }
 
 impl Default for PrismToken {
     #[inline(never)]
     fn default() -> PrismToken {
-        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 2] }
+        PrismToken {
+            authority: Default::default(),
+            bump: Default::default(),
+            mint: Default::default(),
+            assets: Vec::new(),
+        }
     }
 }
 

--- a/programs/splitcoin-prism/src/state.rs
+++ b/programs/splitcoin-prism/src/state.rs
@@ -18,13 +18,13 @@ pub struct PrismToken {
     /// [Mint] of the [PrismToken]
     pub mint: Pubkey,
     /// [AssetData] array
-    pub assets: [AssetData; 256],
+    pub assets: [AssetData; 4],
 }
 
 impl Default for PrismToken {
     #[inline(never)]
     fn default() -> PrismToken {
-        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 256] }
+        PrismToken { authority: Default::default(), bump: Default::default(), mint: Default::default(), assets: [AssetData::default(); 4] }
     }
 }
 

--- a/programs/splitcoin-prism/src/util.rs
+++ b/programs/splitcoin-prism/src/util.rs
@@ -1,9 +1,9 @@
-use crate::{state::PrismToken, asset_data::ReadablePrice};
+use crate::{asset_data::{ReadablePrice, AssetData}};
 
 /// Helper function that returns Prism token's value
-pub fn token_value(prism_token: PrismToken) -> i64 {
+pub fn token_value(asset_data: &Vec<AssetData>) -> i64 {
     let mut sum: i64 = 0;
-    prism_token.assets.iter().for_each(|asset| {
+    asset_data.iter().for_each(|asset| {
         sum += asset.data_feed.get_price().price * asset.weight;
     });
     sum

--- a/programs/splitcoin-prism/src/util.rs
+++ b/programs/splitcoin-prism/src/util.rs
@@ -1,7 +1,8 @@
-use crate::{asset_data::{ReadablePrice, AssetData}};
+use crate::asset_data::{AssetData, ReadablePrice};
 
+// TODO replace 8 with shared max size
 /// Helper function that returns Prism token's value
-pub fn token_value(asset_data: &Vec<AssetData>) -> i64 {
+pub fn token_value(asset_data: &[AssetData; 8]) -> i64 {
     let mut sum: i64 = 0;
     asset_data.iter().for_each(|asset| {
         sum += asset.data_feed.get_price().price * asset.weight;

--- a/programs/splitcoin-prism/src/util.rs
+++ b/programs/splitcoin-prism/src/util.rs
@@ -1,0 +1,10 @@
+use crate::{state::PrismToken, asset_data::ReadablePrice};
+
+/// Helper function that returns Prism token's value
+pub fn token_value(prism_token: PrismToken) -> i64 {
+    let mut sum: i64 = 0;
+    prism_token.assets.iter().for_each(|asset| {
+        sum += asset.data_feed.get_price().price * asset.weight;
+    });
+    sum
+}

--- a/src/pda.ts
+++ b/src/pda.ts
@@ -10,11 +10,11 @@ export const generatePrismAddress = (): Promise<[PublicKey, number]> => {
   );
 };
 
-export const generatePrismAssetAddress = (
+export const generatePrismTokenAddress = (
   mint: PublicKey
 ): Promise<[PublicKey, number]> => {
   return PublicKey.findProgramAddress(
-    [utils.bytes.utf8.encode("PrismAsset"), mint.toBuffer()],
+    [utils.bytes.utf8.encode("PrismToken"), mint.toBuffer()],
     PROGRAM_ID
   );
 };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import type { Idl } from "@project-serum/anchor";
 import { newProgram } from "@saberhq/anchor-contrib";
 import type { AugmentedProvider, Provider } from "@saberhq/solana-contrib";
 import {
@@ -26,9 +29,20 @@ export class SplitcoinPrismSDK {
 
   static load({ provider }: { provider: Provider }): SplitcoinPrismSDK {
     const aug = new SolanaAugmentedProvider(provider);
+    const inserted = {
+      ...IDL,
+      types: [
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        ...IDL.types,
+        {
+          ...IDL.types.find((t) => t.name === "ConstantValueFeed"),
+          name: "Feed",
+        },
+      ],
+    };
     return new SplitcoinPrismSDK(
       aug,
-      newProgram<PrismProgram>(IDL, PROGRAM_ID, aug)
+      newProgram<PrismProgram>(inserted as Idl, PROGRAM_ID, aug)
     );
   }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -62,6 +62,7 @@ export class SplitcoinPrismSDK {
     mintKP?: Keypair;
     authority: PublicKey;
     assets: AssetData[];
+    tokenHolders?: PublicKey[];
   }): Promise<TransactionEnvelope> {
     const [prismTokenKey, bump] = await generatePrismTokenAddress(
       mintKP.publicKey
@@ -79,7 +80,7 @@ export class SplitcoinPrismSDK {
       await getOrCreateATA({
         provider: this.provider,
         mint: mintKP.publicKey,
-        owner: prismTokenKey,
+        owner: authority,
       })
     ).instruction;
     const initPrismAndCreateAtaTx = new TransactionEnvelope(this.provider, [

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -86,7 +86,6 @@ export class SplitcoinPrismSDK {
       }),
       ...(ataInstruction ? [ataInstruction] : []),
     ]);
-
     return initMintTX.combine(initPrismAndCreateAtaTx);
   }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import type { Idl } from "@project-serum/anchor";
 import { newProgram } from "@saberhq/anchor-contrib";
 import type { AugmentedProvider, Provider } from "@saberhq/solana-contrib";
 import {
@@ -32,20 +31,9 @@ export class SplitcoinPrismSDK {
 
   static load({ provider }: { provider: Provider }): SplitcoinPrismSDK {
     const aug = new SolanaAugmentedProvider(provider);
-    const inserted = {
-      ...IDL,
-      types: [
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ...IDL.types,
-        {
-          ...IDL.types.find((t) => t.name === "ConstantValueFeed"),
-          name: "Feed",
-        },
-      ],
-    };
     return new SplitcoinPrismSDK(
       aug,
-      newProgram<PrismProgram>(inserted as Idl, PROGRAM_ID, aug)
+      newProgram<PrismProgram>(IDL, PROGRAM_ID, aug)
     );
   }
 
@@ -102,9 +90,6 @@ export class SplitcoinPrismSDK {
           tokenMint: mintKP.publicKey,
           systemProgram: SystemProgram.programId,
         },
-        preInstructions: [
-          await this.program.account.prismToken.createInstruction(mintKP, 1000),
-        ],
       }),
       ...(ataInstruction ? [ataInstruction] : []),
     ]);
@@ -116,7 +101,7 @@ export class SplitcoinPrismSDK {
     return (await this.program.account.prism.fetchNullable(key)) as PrismData;
   }
 
-  async fetchAssetData(key: PublicKey): Promise<PrismTokenData | null> {
+  async fetchPrismTokenData(key: PublicKey): Promise<PrismTokenData | null> {
     return (await this.program.account.prismToken.fetchNullable(
       key
     )) as PrismTokenData;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,17 +38,6 @@ export class SplitcoinPrismSDK {
           ...IDL.types.find((t) => t.name === "ConstantValueFeed"),
           name: "Feed",
         },
-        {
-          type: {
-            array: [
-              {
-                defined: "AssetData",
-              },
-              IDL.constants[0].value,
-            ],
-          },
-          name: `Box<[AssetData;NUM_ASSETS]>`,
-        },
       ],
     };
     return new SplitcoinPrismSDK(

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,16 +5,16 @@ import type { SplitcoinPrism } from "../target/types/splitcoin_prism";
 export type PrismTypes = AnchorTypes<
   SplitcoinPrism,
   {
-    prismAsset: PrismAssetData;
+    prismToken: PrismTokenData;
     prism: PrismData;
   },
   {
-    Feed: ConstantValueFeed;
+    dataFeed: ConstantValueFeed;
   }
 >;
 
 type Accounts = PrismTypes["Accounts"];
-export type PrismAssetData = Accounts["prismAsset"];
+export type PrismTokenData = Accounts["prismToken"];
 export type PrismData = Accounts["prism"];
 export type PrismProgram = PrismTypes["Program"];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,20 @@ import type { SplitcoinPrism } from "../target/types/splitcoin_prism";
 
 export type PrismTypes = AnchorTypes<
   SplitcoinPrism,
-  { prismAsset: PrismAssetData; prism: PrismData }
+  {
+    prismAsset: PrismAssetData;
+    prism: PrismData;
+  },
+  {
+    Feed: ConstantValueFeed;
+  }
 >;
 
 type Accounts = PrismTypes["Accounts"];
 export type PrismAssetData = Accounts["prismAsset"];
 export type PrismData = Accounts["prism"];
 export type PrismProgram = PrismTypes["Program"];
+
+export type Defined = PrismTypes["Defined"];
+export type AssetData = Defined["AssetData"];
+export type ConstantValueFeed = Defined["ConstantValueFeed"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type PrismTypes = AnchorTypes<
     prism: PrismData;
   },
   {
-    dataFeed: ConstantValueFeed;
+    feed: Feed;
   }
 >;
 
@@ -20,4 +20,4 @@ export type PrismProgram = PrismTypes["Program"];
 
 export type Defined = PrismTypes["Defined"];
 export type AssetData = Defined["AssetData"];
-export type ConstantValueFeed = Defined["ConstantValueFeed"];
+export type Feed = Defined["Feed"];

--- a/tests/splitcoin-prism.ts
+++ b/tests/splitcoin-prism.ts
@@ -6,8 +6,10 @@ import type {
   PublicKey,
 } from "@saberhq/solana-contrib";
 import { Keypair } from "@solana/web3.js";
+import { BN } from "bn.js";
 import chai, { expect } from "chai";
 
+import type { AssetData } from "../src";
 import {
   generatePrismAddress,
   generatePrismTokenAddress,
@@ -49,19 +51,34 @@ describe("splitcoin-prism", () => {
   });
 
   it("Initializes a prism asset", async () => {
+    const assetData: AssetData[] = [
+      {
+        dataFeed: { constant: { price: new BN(9), expo: 9 } },
+        weight: new BN(4),
+      },
+      {
+        dataFeed: { constant: { price: new BN(9), expo: 9 } },
+        weight: new BN(1),
+      },
+      {
+        dataFeed: { constant: { price: new BN(9), expo: 9 } },
+        weight: new BN(2),
+      },
+    ];
+
     const tx = await sdk.registerToken({
       mintKP,
-      assets: [],
+      assets: assetData,
       authority,
     });
     await expectTX(tx, "Initialize asset with assetToken").to.be.fulfilled;
 
     const [tokenKey, bump] = await generatePrismTokenAddress(mintKP.publicKey);
 
-    const assetData = await sdk.fetchAssetData(tokenKey);
+    const tokenData = await sdk.fetchPrismTokenData(tokenKey);
 
-    expect(assetData?.authority).to.eqAddress(authority);
-    expect(assetData?.bump).to.equal(bump);
-    expect(assetData?.mint).to.eqAddress(mintKP.publicKey);
+    expect(tokenData?.authority).to.eqAddress(authority);
+    expect(tokenData?.bump).to.equal(bump);
+    expect(tokenData?.mint).to.eqAddress(mintKP.publicKey);
   });
 });

--- a/tests/splitcoin-prism.ts
+++ b/tests/splitcoin-prism.ts
@@ -54,7 +54,7 @@ describe("splitcoin-prism", () => {
   it("Initializes a prism asset", async () => {
     const tx = await sdk.registerToken({
       mintKP,
-      decimals: assetToken.decimals,
+      assets: [],
       authority,
     });
     await expectTX(tx, "Initialize asset with assetToken").to.be.fulfilled;

--- a/tests/splitcoin-prism.ts
+++ b/tests/splitcoin-prism.ts
@@ -5,7 +5,6 @@ import type {
   Provider as SaberProvider,
   PublicKey,
 } from "@saberhq/solana-contrib";
-import { Token } from "@saberhq/token-utils";
 import { Keypair } from "@solana/web3.js";
 import chai, { expect } from "chai";
 
@@ -30,13 +29,11 @@ describe("splitcoin-prism", () => {
   // Helper variables
   let authority: PublicKey;
   let mintKP: Keypair;
-  let assetToken: Token;
 
   // Unit tests
   it("Initialize test state", () => {
     authority = provider.wallet.publicKey;
     mintKP = Keypair.generate();
-    assetToken = Token.fromMint(mintKP.publicKey, 12);
   });
 
   it("Initialize prism program state", async () => {

--- a/tests/splitcoin-prism.ts
+++ b/tests/splitcoin-prism.ts
@@ -11,7 +11,7 @@ import chai, { expect } from "chai";
 
 import {
   generatePrismAddress,
-  generatePrismAssetAddress,
+  generatePrismTokenAddress,
   SplitcoinPrismSDK,
 } from "../src";
 
@@ -52,16 +52,16 @@ describe("splitcoin-prism", () => {
   });
 
   it("Initializes a prism asset", async () => {
-    const tx = await sdk.newAsset({
+    const tx = await sdk.registerToken({
       mintKP,
       decimals: assetToken.decimals,
       authority,
     });
     await expectTX(tx, "Initialize asset with assetToken").to.be.fulfilled;
 
-    const [assetKey, bump] = await generatePrismAssetAddress(mintKP.publicKey);
+    const [tokenKey, bump] = await generatePrismTokenAddress(mintKP.publicKey);
 
-    const assetData = await sdk.fetchAssetData(assetKey);
+    const assetData = await sdk.fetchAssetData(tokenKey);
 
     expect(assetData?.authority).to.eqAddress(authority);
     expect(assetData?.bump).to.equal(bump);


### PR DESCRIPTION
## JIRA
## Problem

When you called `registerToken` through the sdk, an ATA was created for the Prism account. This is not breaking nor a bug but doesn't make much sense.

## Solution

Instead, let's create an ATA for the authority passed into the function. This means that whoever registers a Prism also get's a token account, for the autogenerated SPL-Token, created for them.

## Unit Tests

Passing

## Invocation

If your changes modify or add some kind of user invoked script or command, please describe how to use what you've changed / added.

### Sanity Check Steps

- [X] Tested by submitter
- [X] Checked there are no console errors or warnings
- [X] All tests are passing
- [X] ESLint/Prettier isn't throwing any unignored errors or warnings
