### PR TITLE
QOL: Change ATA created from prism to authority

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -72,7 +72,7 @@ export class SplitcoinPrismSDK {
       await getOrCreateATA({
         provider: this.provider,
         mint: mintKP.publicKey,
-        owner: assetKey,
+        owner: authority,
       })
     ).instruction;
     const initPrismAndCreateAtaTx = new TransactionEnvelope(this.provider, [


### PR DESCRIPTION
## Problem

Register token creates an ATA account for the Prism being registered. While not a bug this is not needed.

## Solution

Let's change this to create an ATA for the `authority` passed that way the registree of the Prism automatically has an ATA created for them!

### Sanity Check Steps

- [X] Tested by submitter
- [X] Checked there are no console errors or warnings
- [X] All tests are passing
- [X] ESLint/Prettier isn't throwing any unignored errors or warnings
