### PR TITLE
Fixed issue with tests timing out

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -10,3 +10,6 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+
+[test]
+startup_wait = 30000


### PR DESCRIPTION
## Problem

Finally fixed dumb error I've been suffering through for the last 24 hours. Increases the default timeout for running tests with anchor test, or in our case yarn test, to 30 seconds. *insert moaning sounds here* 😄 🖕 

### Sanity Check Steps

- [x] All tests are passing
