### PR TITLE
Rounding errors fix

### DIFF
--- a/programs/coherence-beamsplitter/src/errors.rs
+++ b/programs/coherence-beamsplitter/src/errors.rs
@@ -48,4 +48,8 @@ pub enum BeamsplitterErrors {
         "Attempted to register prism etf but freeze authority exists and it's not Beamsplitter for passed token mint"
     )]
     NotFreezeAuthority, // 6019 - 0x1783
+    #[msg(
+        "The calculated fees were higher than the orderers received `mint_amount`, potentially resulting in underflow."
+    )]
+    PotentialUnderflow, // 6019 - 0x1783
 }

--- a/programs/coherence-beamsplitter/src/lib.rs
+++ b/programs/coherence-beamsplitter/src/lib.rs
@@ -321,9 +321,7 @@ pub mod coherence_beamsplitter {
             .ok_or(BeamsplitterErrors::U64Failure)?;
 
         // This rounds up to 1 if the value was extremely small (prevent free cohere)
-        if required_64 <= 0 {
-            required_64 = 1;
-        };
+        required_64 += 1;
 
         transfer(transfer_ctx, required_64)?;
 

--- a/programs/coherence-beamsplitter/src/lib.rs
+++ b/programs/coherence-beamsplitter/src/lib.rs
@@ -491,6 +491,10 @@ pub mod coherence_beamsplitter {
             fee_portion = Decimal::from(1u8);
         }
 
+        if mint_amount <= fee_portion {
+            return Err(BeamsplitterErrors::PotentialUnderflow.into());
+        }
+
         // Subtract out the construction fee from orderer amount
         mint_amount.sub_assign(fee_portion);
 

--- a/programs/coherence-beamsplitter/src/lib.rs
+++ b/programs/coherence-beamsplitter/src/lib.rs
@@ -320,7 +320,8 @@ pub mod coherence_beamsplitter {
             .to_u64()
             .ok_or(BeamsplitterErrors::U64Failure)?;
 
-        // This rounds up to 1 if the value was extremely small (prevent free cohere)
+        // This used to round up by default. Ex. if required_amount = 1.5, we must take 2. We always round up 1 even if required amount is 1.0 (becomes 2)
+        // This prevents free coheres where required amount could equal 0.2 and gets truncated to 0
         required_64 += 1;
 
         transfer(transfer_ctx, required_64)?;
@@ -496,6 +497,15 @@ pub mod coherence_beamsplitter {
         // Subtract out the manager portion from fee portion
         fee_portion.sub_assign(manager_portion);
 
+        let mut mint_amount_u64 = mint_amount.to_u64().ok_or(BeamsplitterErrors::U64Failure)?;
+        let fee_portion_u64 = fee_portion.to_u64().ok_or(BeamsplitterErrors::U64Failure)?;
+        let manager_portion_u64 = manager_portion
+            .to_u64()
+            .ok_or(BeamsplitterErrors::U64Failure)?;
+
+        // Add back any lost to rounding
+        mint_amount_u64 += amount - (mint_amount_u64 + fee_portion_u64 + manager_portion_u64);
+
         // Mint tokens to the orderer
         let mint_accounts_orderer = MintTo {
             mint: ctx.accounts.prism_etf_mint.to_account_info(),
@@ -512,10 +522,7 @@ pub mod coherence_beamsplitter {
             signer_seeds,
         );
 
-        mint_to(
-            mint_ctx_orderer,
-            mint_amount.to_u64().ok_or(BeamsplitterErrors::U64Failure)?,
-        )?;
+        mint_to(mint_ctx_orderer, mint_amount_u64)?;
 
         // Mint tokens to Program owner
         let mint_accounts_owner = MintTo {
@@ -533,10 +540,7 @@ pub mod coherence_beamsplitter {
             signer_seeds,
         );
 
-        mint_to(
-            mint_ctx_owner,
-            fee_portion.to_u64().ok_or(BeamsplitterErrors::U64Failure)?,
-        )?;
+        mint_to(mint_ctx_owner, fee_portion_u64)?;
 
         // Mint tokens to Manager of ETF
         let mint_accounts_manager = MintTo {
@@ -554,12 +558,7 @@ pub mod coherence_beamsplitter {
             signer_seeds,
         );
 
-        mint_to(
-            mint_ctx_manager,
-            manager_portion
-                .to_u64()
-                .ok_or(BeamsplitterErrors::U64Failure)?,
-        )?;
+        mint_to(mint_ctx_manager, manager_portion_u64)?;
 
         order_state.status = OrderStatus::SUCCEEDED;
 

--- a/src/coherence_beamsplitter.ts
+++ b/src/coherence_beamsplitter.ts
@@ -1238,6 +1238,11 @@ export type CoherenceBeamsplitter = {
       "code": 6019,
       "name": "NotFreezeAuthority",
       "msg": "Attempted to register prism etf but freeze authority exists and it's not Beamsplitter for passed token mint"
+    },
+    {
+      "code": 6020,
+      "name": "PotentialUnderflow",
+      "msg": "The calculated fees were higher than the orderers received `mint_amount`, potentially resulting in underflow."
     }
   ]
 };
@@ -2482,6 +2487,11 @@ export const IDL: CoherenceBeamsplitter = {
       "code": 6019,
       "name": "NotFreezeAuthority",
       "msg": "Attempted to register prism etf but freeze authority exists and it's not Beamsplitter for passed token mint"
+    },
+    {
+      "code": 6020,
+      "name": "PotentialUnderflow",
+      "msg": "The calculated fees were higher than the orderers received `mint_amount`, potentially resulting in underflow."
     }
   ]
 };

--- a/tests/coherence-beamsplitter.ts
+++ b/tests/coherence-beamsplitter.ts
@@ -254,9 +254,9 @@ describe("coherence-beamsplitter", () => {
     let transferredTokensAcct: PublicKey;
     let weightedTokens: WeightedToken[];
 
-    const decimalsA = 4;
+    const decimalsA = 6;
     const decimalsB = 11;
-    const tokenAWeight = new BN(3);
+    const tokenAWeight = new BN(3246753);
     const tokenBWeight = new BN(7);
 
     /*
@@ -408,7 +408,7 @@ describe("coherence-beamsplitter", () => {
     it(`Construct two asset Prism ETF`, async () => {
       const _scalar =
         10 ** (await getMintInfo(provider, prismEtfMint)).decimals;
-      const AMOUNT_TO_CONSTRUCT = new BN(1).mul(new BN(_scalar));
+      const AMOUNT_TO_CONSTRUCT = new BN(1800266);
 
       const tokenABalBefore = (await getTokenAccount(provider, tokenAATA))
         .amount;

--- a/tests/coherence-beamsplitter.ts
+++ b/tests/coherence-beamsplitter.ts
@@ -512,7 +512,9 @@ describe("coherence-beamsplitter", () => {
 
       let expectedADiff = AMOUNT_TO_CONSTRUCT.mul(
         new BN(weightedTokens[0]?.weight)
-      ).div(new BN(scalarA));
+      )
+        .div(new BN(scalarA))
+        .add(new BN(1));
 
       expectedADiff = expectedADiff.lte(new BN(0)) ? new BN(1) : expectedADiff;
 
@@ -531,7 +533,9 @@ describe("coherence-beamsplitter", () => {
 
       let expectedBDiff = AMOUNT_TO_CONSTRUCT.mul(
         new BN(weightedTokens[1]?.weight)
-      ).div(new BN(scalarB));
+      )
+        .div(new BN(scalarB))
+        .add(new BN(1));
 
       expectedBDiff = expectedBDiff.lte(new BN(0)) ? new BN(1) : expectedBDiff;
 
@@ -806,7 +810,7 @@ describe("coherence-beamsplitter", () => {
         return new Error("weight B undefined");
       }
 
-      const expectedBDiff = new BN(0);
+      const expectedBDiff = new BN(-1);
 
       assert(actualTokenBBalDiff.eq(expectedBDiff));
     });
@@ -1251,7 +1255,7 @@ describe("coherence-beamsplitter", () => {
         return new Error("weight B undefined");
       }
 
-      const expectedBDiff = new BN(0);
+      const expectedBDiff = new BN(-1);
 
       assert(actualTokenBBalDiff.eq(expectedBDiff));
     });


### PR DESCRIPTION
## Problem

A. During cohere if the `required_amount` had a decimal component it would be truncated resulting in the program taking one less unit of the asset than required. Therefore, the etf was underbacked and not all assets could be removed.
B. Up to 2 units of etf tokens were not minted because of truncation. If the portions of fees had a decimal component they would be lost. IE if the amount to be minted was 9. 20% of this would 1.8, and because of truncation, only 1 would be minted to the 20% cut.

## Solution

A. Always round up by 1 on the amount transferred during cohere
B. A calculation is done to recover any tokens lost to truncation, they are credited to the orderer.

## Unit Tests

Yessir

### Sanity Check Steps

- [X] Tested by submitter
- [X] All linked JIRA tasks requirements are satisfied -- (ignore if you are not an internal team member)
- [X] Checked there are no console errors or warnings
- [X] All tests are passing
- [X] ESLint/Prettier isn't throwing any unignored errors or warnings
